### PR TITLE
Extended the RegExp for C++ symbols.

### DIFF
--- a/src/demanglers/cpp.ts
+++ b/src/demanglers/cpp.ts
@@ -23,7 +23,7 @@ import { canSpawnSync, spawnDemanglerSync } from "../spawn";
  * This demangler does not provide additional hover information.
  */
 export class CppDemangler implements IDemangler {
-  mangledSymbolPattern = /_{1,2}ZN?\d+\w+/g;
+  mangledSymbolPattern = /_{1,2}Z[IKNTV]*(St)?\d*[$\w]+/g;
 
   /** The view of the path settings for this demangler. */
   private pathSettings: DemanglerPathSettings;


### PR DESCRIPTION
The previous RegExp only caught a small fraction of the symbols that actually occur. This one might still be incomplete, but it catches many more symbols than before, like `operator new` and `operator delete`, among others.